### PR TITLE
Repopulate previously loaded data

### DIFF
--- a/eit_dash/callbacks/load_callbacks.py
+++ b/eit_dash/callbacks/load_callbacks.py
@@ -156,7 +156,7 @@ def load_selected_data(data_path, cancel_load, sig, file_type, fig):
 
 
 @callback(
-    Output(ids.DATASET_CONTAINER, "children"),
+    Output(ids.DATASET_CONTAINER, "children", allow_duplicate=True),
     Input(ids.LOAD_CONFIRM_BUTTON, "n_clicks"),
     State(ids.NFILES_PLACEHOLDER, "children"),
     State(ids.DATASET_CONTAINER, "children"),
@@ -286,3 +286,16 @@ def store_clicked_file(n_clicks, title):
             return state["value"]
 
     return None
+
+
+# Repopulate data after reload
+@callback(
+    Output(ids.DATASET_CONTAINER, "children", allow_duplicate=True),
+    Input(ids.POPULATE_DATA, "children"),
+    prevent_initial_call="initial_duplicate",
+)
+def repopulate_data(reload):
+    """Repopulate data after reloading page."""
+    # create the info summary card
+    reloaded_data = data_object.get_all_sequences()
+    return [create_info_card(element) for element in reloaded_data]

--- a/eit_dash/definitions/element_ids.py
+++ b/eit_dash/definitions/element_ids.py
@@ -29,6 +29,7 @@ LOAD_CONFIRM_BUTTON = "load-confirm-button"
 LOAD_CANCEL_BUTTON = "load-cancel-button"
 LOAD_RESULTS_TITLE = "load-results-title"
 PARENT_DIR = "parent-dir"
+POPULATE_DATA = "populate-data"
 STORED_CWD = "stored-cwd"
 SELECT_CONFIRM_BUTTON = "select-confirm-button"
 

--- a/eit_dash/pages/load.py
+++ b/eit_dash/pages/load.py
@@ -152,6 +152,9 @@ modal_dialog = html.Div(
     ],
 )
 
+# This is a placeholder for triggering repopulating of data when page is reloaded
+populate_loaded_data = html.Div(id=ids.POPULATE_DATA)
+
 layout = dbc.Row(
     [
         html.H1("LOAD DATA", style=styles.COLUMN_TITLE),
@@ -160,6 +163,7 @@ layout = dbc.Row(
         results,
         placeholder_nfiles,
         modal_dialog,
+        populate_loaded_data,
         # TODO: the following is duplicated in multiple pages. To be refactored
         html.Div(
             [


### PR DESCRIPTION
Fix #52 
Added empty element to trigger repopulating of previously loaded data when reloading load data page.