### PR TITLE
fix imports

### DIFF
--- a/eit_dash/utils/common.py
+++ b/eit_dash/utils/common.py
@@ -13,7 +13,7 @@ from eit_dash.definitions import layout_styles as styles
 from eit_dash.definitions.constants import RAW_EIT_LABEL
 
 if TYPE_CHECKING:
-    from eitprocessing.sequence import Sequence
+    from eitprocessing.datahandling.sequence import Sequence
 
     from eit_dash.utils.data_singleton import Period
 

--- a/eit_dash/utils/data_singleton.py
+++ b/eit_dash/utils/data_singleton.py
@@ -5,7 +5,7 @@ from threading import Lock
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from eitprocessing.sequence import Sequence
+    from eitprocessing.datahandling.sequence import Sequence
 
 
 _singleton = None


### PR DESCRIPTION
I accidentally discovered that these imports were outdated.

For some reason the build workflow still worked despite these imports not being accurate. That is a bit concerning, isn't it?